### PR TITLE
New structure for XML parsing - Vehicle sensors - ROSInterface, with an example

### DIFF
--- a/UWSim/CMakeLists.txt
+++ b/UWSim/CMakeLists.txt
@@ -94,6 +94,7 @@ src/BulletHfFluid/btHfFluidRigidCollisionAlgorithm.cpp
 src/BulletHfFluid/btHfFluidRigidCollisionConfiguration.cpp
 src/BulletHfFluid/btHfFluidRigidDynamicsWorld.cpp
 src/BulletHfFluid/BuoyantShapeConvexCollisionAlgorithm.cpp
+src/SimulatedDevices.cpp
 )
 
 rosbuild_add_executable(UWSim  src/main.cpp)

--- a/UWSim/CMakeLists.txt
+++ b/UWSim/CMakeLists.txt
@@ -95,6 +95,7 @@ src/BulletHfFluid/btHfFluidRigidCollisionConfiguration.cpp
 src/BulletHfFluid/btHfFluidRigidDynamicsWorld.cpp
 src/BulletHfFluid/BuoyantShapeConvexCollisionAlgorithm.cpp
 src/SimulatedDevices.cpp
+src/SimulatedDevice_Echo.cpp
 )
 
 rosbuild_add_executable(UWSim  src/main.cpp)

--- a/UWSim/data/scenes/UWSimScene.dtd
+++ b/UWSim/data/scenes/UWSimScene.dtd
@@ -159,8 +159,11 @@
 
 <!-- simulatedDevice -->
 <!ELEMENT simulatedDevice (name
+,echo?
 )>
 <!ELEMENT SimulatedDeviceROS (
-#PCDATA
+echoROS?
 )>
+<!ELEMENT echo (info)>
+<!ELEMENT echoROS (name, topic, rate?)>
 

--- a/UWSim/data/scenes/UWSimScene.dtd
+++ b/UWSim/data/scenes/UWSimScene.dtd
@@ -3,7 +3,7 @@
 <!-- elementos oceanScene -->
 <!ELEMENT oceanState (windx?,windy?,windSpeed?,depth?,reflectionDamping?,waveScale?,isNotChoppy?,choppyFactor?,crestFoamHeight?,oceanSurfaceHeight?,fog?,color?,attenuation?)>
 <!ELEMENT simParams (disableShaders?,resw?,resh?,offsetp?,offsetr?,enablePhysics?,gravity?,physicsWater?)>
-<!ELEMENT vehicle (name,file,jointValues?,position?,orientation?,virtualCamera*, rangeSensor*, objectPicker*, imu*, pressureSensor*, gpsSensor*, dvlSensor*, virtualRangeImage*,multibeamSensor*)>
+<!ELEMENT vehicle (name,file,jointValues?,position?,orientation?,virtualCamera*, rangeSensor*, objectPicker*, imu*, pressureSensor*, gpsSensor*, dvlSensor*, virtualRangeImage*,multibeamSensor*, simulatedDevice*)>
 <!ELEMENT virtualCamera (name,relativeTo,resw?,resh?,position?,orientation?,baseline?,frameId?, parameters?, showpath?)>
 <!ELEMENT virtualRangeImage (name,relativeTo,resw?,resh?,position?,orientation?,parameters?)>
 <!ELEMENT rangeSensor (name,relativeTo,range,visible?,position?,orientation?)>
@@ -15,7 +15,7 @@
 <!ELEMENT multibeamSensor (name,relativeTo,position?,orientation?, initAngle,finalAngle, angleIncr,range)>
 <!ELEMENT camera (freeMotion?,objectToTrack?,fov?,aspectRatio?,near?,far?,position?,lookAt?) >
 <!ELEMENT object (name,file,position,orientation,offsetp?,offsetr?,physics?)>
-<!ELEMENT rosInterfaces ((ROSOdomToPAT*)?, (PATToROSOdom*)?, (ArmToROSJointState*)?, (ROSJointStateToArm*)?, (VirtualCameraToROSImage*)?, (ROSImageToHUD*)?,(ROSTwistToPAT*)?, (RangeSensorToROSRange*)?, (ROSPoseToPAT*)?, (ImuToROSImu*)?, (PressureSensorToROS*)?, (GPSSensorToROS*)?, (DVLSensorToROS*)?, (RangeImageSensorToROSImage*)?,(multibeamSensorToLaserScan*)?)>
+<!ELEMENT rosInterfaces ((ROSOdomToPAT*)?, (PATToROSOdom*)?, (ArmToROSJointState*)?, (ROSJointStateToArm*)?, (VirtualCameraToROSImage*)?, (ROSImageToHUD*)?,(ROSTwistToPAT*)?, (RangeSensorToROSRange*)?, (ROSPoseToPAT*)?, (ImuToROSImu*)?, (PressureSensorToROS*)?, (GPSSensorToROS*)?, (DVLSensorToROS*)?, (RangeImageSensorToROSImage*)?,(multibeamSensorToLaserScan*)?, (SimulatedDeviceROS*)?)>
 
 <!-- elementos comunes -->
 <!ELEMENT position (x,y,z)>
@@ -155,3 +155,12 @@
 <!ELEMENT isKinematic (#PCDATA)>
 <!ELEMENT minAngularLimit (x,y,z)>
 <!ELEMENT maxAngularLimit (x,y,z)>
+
+
+<!-- simulatedDevice -->
+<!ELEMENT simulatedDevice (name
+)>
+<!ELEMENT SimulatedDeviceROS (
+#PCDATA
+)>
+

--- a/UWSim/data/scenes/cirs.xml
+++ b/UWSim/data/scenes/cirs.xml
@@ -248,7 +248,12 @@
       <angleIncr>0.1</angleIncr>
       <range>10</range>
     </multibeamSensor>
-
+    <simulatedDevice>
+      <name>echo_example</name>
+      <echo>
+        <info>Echo info 123...</info>
+      </echo>
+    </simulatedDevice>
   </vehicle>
 
   <object>
@@ -366,6 +371,13 @@
       <name>multibeam</name>
       <topic>g500/multibeam</topic>
     </multibeamSensorToLaserScan>
+    <SimulatedDeviceROS>
+	  <echoROS>
+	    <name>echo_example</name>
+	    <topic>g500/echo</topic>
+	    <rate>1</rate>
+	  </echoROS>
+    </SimulatedDeviceROS>
   </rosInterfaces>
 </UWSimScene>
 

--- a/UWSim/src/ConfigXMLParser.h
+++ b/UWSim/src/ConfigXMLParser.h
@@ -17,6 +17,7 @@
 #ifndef CONFIGXMLPARSER_H_
 #define CONFIGXMLPARSER_H_
 
+#include "SimulatedDevices.h"
 #include <libxml++/libxml++.h>
 #include <urdf/model.h>
 
@@ -26,7 +27,8 @@ using namespace std;
 #include <list>
 
 struct ROSInterfaceInfo{
-  typedef enum {Unknown, ROSOdomToPAT, PATToROSOdom, ROSJointStateToArm, ArmToROSJointState, VirtualCameraToROSImage, RangeSensorToROSRange,ROSImageToHUD, ROSTwistToPAT, ROSPoseToPAT, ImuToROSImu, PressureSensorToROS, GPSSensorToROS, DVLSensorToROS, RangeImageSensorToROSImage,multibeamSensorToLaserScan} type_t;
+  typedef enum {Unknown, ROSOdomToPAT, PATToROSOdom, ROSJointStateToArm, ArmToROSJointState, VirtualCameraToROSImage, RangeSensorToROSRange,ROSImageToHUD, ROSTwistToPAT, ROSPoseToPAT, ImuToROSImu, PressureSensorToROS, GPSSensorToROS, DVLSensorToROS, RangeImageSensorToROSImage,multibeamSensorToLaserScan,SimulatedDevice} type_t;
+  string subtype;//type of SimulatedDevice
   string topic, infoTopic, targetName;
   type_t type; //Type of ROSInterface
   int rate; //if it's necessary
@@ -166,6 +168,7 @@ struct Vehicle{
   std::list<XMLGPSSensor> gps_sensors;
   std::list<XMLDVLSensor> dvl_sensors;
   std::list<XMLMultibeamSensor> multibeam_sensors;
+  std::vector<SimulatedDeviceConfig::Ptr> simulated_devices;
 };
 
 struct PhysicProperties{
@@ -200,7 +203,7 @@ struct PhysicsWater{
 };
 
 class ConfigFile{
-private:
+public://made process and extract methods public to be used in Simulated Devices implementations
 
   void esPi(string in,double &param);
 
@@ -255,5 +258,7 @@ public:
 
   ConfigFile(const std::string &fName);
 };
+
+
 
 #endif

--- a/UWSim/src/SceneBuilder.cpp
+++ b/UWSim/src/SceneBuilder.cpp
@@ -294,6 +294,9 @@ bool SceneBuilder::loadScene(ConfigFile config)
 		if(rosInterface.type==ROSInterfaceInfo::ROSPoseToPAT)
 			iface=boost::shared_ptr<ROSPoseToPAT>(new ROSPoseToPAT(root,rosInterface.topic,rosInterface.targetName));
 
+		if(rosInterface.type==ROSInterfaceInfo::SimulatedDevice)
+			iface=SimulatedDevices::getInterface(rosInterface,iauvFile);
+
 		ROSInterfaces.push_back(iface);
 		config.ROSInterfaces.pop_front();
 	}

--- a/UWSim/src/SimulatedDevice_Echo.cpp
+++ b/UWSim/src/SimulatedDevice_Echo.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2013 Tallinn University of Technology.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     Yuri Gavshin
+ */
+
+#include "SimulatedDevice_EchoImpl.h"
+
+SimulatedDevice_Echo::SimulatedDevice_Echo(SimulatedDeviceConfig_Echo * cfg): SimulatedDevice(cfg) {
+	this->info = cfg->info;
+}
+
+
+SimulatedDeviceConfig_Echo::SimulatedDeviceConfig_Echo(): SimulatedDeviceConfig("echo") {
+
+}
+
+SimulatedDeviceConfig::Ptr SimulatedDeviceConfig_Echo::processConfig(const xmlpp::Node* node, ConfigFile * config){
+	SimulatedDeviceConfig_Echo * cfg = new SimulatedDeviceConfig_Echo();
+	xmlpp::Node::NodeList list = node->get_children();
+	for(xmlpp::Node::NodeList::iterator iter = list.begin(); iter != list.end(); ++iter){
+		xmlpp::Node* child=dynamic_cast<const xmlpp::Node*>(*iter);
+		//std::cout << "cn="<<child->get_name()<<std::endl;
+		if(child->get_name()=="info")
+			config->extractStringChar(child,cfg->info);
+		//std::cout << "info="<<this->info<<std::endl;
+	}
+	return SimulatedDeviceConfig::Ptr(cfg);
+}
+
+void SimulatedDeviceConfig_Echo::applyConfig( SimulatedIAUV * auv, Vehicle &vehicleChars){
+	for (size_t i=0; i< vehicleChars.simulated_devices.size(); ++i)
+		if (vehicleChars.simulated_devices[i]->type == this->type){
+			SimulatedDeviceConfig_Echo * cfg = static_cast<SimulatedDeviceConfig_Echo *>(vehicleChars.simulated_devices[i].get());
+			//std::cout << "info2="<<this->info<<", info3="<<cfg->info<<std::endl;
+			if (cfg->info.length()>0){
+				auv->devices->all.push_back(SimulatedDevice_Echo::Ptr(new SimulatedDevice_Echo(cfg)));
+			}
+			else
+				ROS_WARN("Echo device '%s' inside robot '%s' has empty info, discarding...", vehicleChars.simulated_devices[i]->name.c_str(),vehicleChars.name.c_str());
+		}
+}
+
+boost::shared_ptr<ROSInterface> SimulatedDeviceConfig_Echo::getInterface(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile){
+	//return boost::shared_ptr<ROSInterface>( new SimulatedDeviceROS_Echo(NULL, rosInterface.topic, rosInterface.rate) );//it is possible to have ROS interface without any device
+	for (size_t i=0;i<iauvFile.size();++i)
+		for (size_t d=0;d<iauvFile[i]->devices->all.size();++d)
+			if (iauvFile[i]->devices->all[d]->type == this->type && iauvFile[i]->devices->all[d]->name == rosInterface.targetName)
+				return boost::shared_ptr<ROSInterface>( new SimulatedDeviceROS_Echo(static_cast<SimulatedDevice_Echo*>(iauvFile[i]->devices->all[d].get()), rosInterface.topic, rosInterface.rate) );
+	ROS_WARN("Returning empty ROS interface for device %s...", rosInterface.targetName.c_str());
+	return boost::shared_ptr<ROSInterface>();
+}
+
+SimulatedDeviceROS_Echo::SimulatedDeviceROS_Echo(SimulatedDevice_Echo *dev, std::string topic, int rate): ROSPublisherInterface(topic,rate), dev(dev) {
+}
+
+void  SimulatedDeviceROS_Echo::createPublisher(ros::NodeHandle &nh) {
+  ROS_INFO("SimulatedDeviceROS_Echo publisher on topic %s",topic.c_str());
+  pub_ = nh.advertise<std_msgs::String>(topic, 1);
+}
+
+void  SimulatedDeviceROS_Echo::publish() {
+	std_msgs::String msg;
+	if (dev!=NULL)
+		msg.data = dev->info;
+	else
+		msg.data = "dev==NULL";
+	pub_.publish(msg);
+}
+
+SimulatedDeviceROS_Echo::~SimulatedDeviceROS_Echo() {}

--- a/UWSim/src/SimulatedDevice_Echo.h
+++ b/UWSim/src/SimulatedDevice_Echo.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2013 Tallinn University of Technology.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     Yuri Gavshin
+ */
+
+#ifndef SIMULATEDDEVICE_ECHO_H_
+#define SIMULATEDDEVICE_ECHO_H_
+#include "SimulatedDevices.h"
+
+/*
+ * Example header of driver/rosinterface configuration/factory
+ *
+ * Included in SimulatedDevices.cpp
+ */
+
+//Driver/ROSInterface configuration/factory class
+class SimulatedDeviceConfig_Echo : public SimulatedDeviceConfig {
+public:
+//XML members
+	std::string info;
+//constructor
+	SimulatedDeviceConfig_Echo();
+//Factory methods
+//for pure ROSInterface implement only getInterface
+//for pure Driver implement only processConfig && applyConfig members
+
+	SimulatedDeviceConfig::Ptr processConfig(const xmlpp::Node* node, ConfigFile * config);
+	void applyConfig( SimulatedIAUV * auv, Vehicle &vehicleChars);
+	boost::shared_ptr<ROSInterface> getInterface(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile);
+};
+
+#endif /* SIMULATEDDEVICE_ECHO_H_ */

--- a/UWSim/src/SimulatedDevice_EchoImpl.h
+++ b/UWSim/src/SimulatedDevice_EchoImpl.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013 Tallinn University of Technology.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     Yuri Gavshin
+ */
+
+/*
+ * Example header of driver/rosinterface implementation
+ *
+ * Included only in driver's cpp file
+ */
+#ifndef SIMULATEDDEVICE_ECHOIMPL_H_
+#define SIMULATEDDEVICE_ECHOIMPL_H_
+#include "SimulatedDevice_Echo.h"
+#include "ConfigXMLParser.h"
+#include "SimulatedIAUV.h"
+#include "ROSInterface.h"
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+//Driver class
+class SimulatedDevice_Echo: public SimulatedDevice {
+public:
+	std::string info;	//Device's property
+
+	SimulatedDevice_Echo(SimulatedDeviceConfig_Echo * cfg);
+};
+
+//ROSInterface class
+class SimulatedDeviceROS_Echo : public ROSPublisherInterface {
+	//this is just an example, use a pointer to SimulatedIAUV, if only ROSInterface is implemented
+	//pointer to a device
+	SimulatedDevice_Echo * dev;
+public:
+	SimulatedDeviceROS_Echo(SimulatedDevice_Echo *dev, std::string topic, int rate);
+
+	void createPublisher(ros::NodeHandle &nh);
+	void publish();
+
+	~SimulatedDeviceROS_Echo();
+};
+
+#endif /* SIMULATEDDEVICE_ECHOIMPL_H_ */

--- a/UWSim/src/SimulatedDevices.cpp
+++ b/UWSim/src/SimulatedDevices.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2013 Tallinn University of Technology.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     Yuri Gavshin
+ */
+
+#include "SimulatedDevices.h"
+#include "ConfigXMLParser.h"
+#include "ros/ros.h"
+
+//a list of "factories" to initialize and apply a device or rosinterface
+//an instance of "config" class is used as both a "factory" and as an XML structure
+std::vector<SimulatedDeviceConfig::Ptr> factories;
+
+//setting up a list of available devices/rosinterfaces
+static void initFactories(){
+	if (factories.size()>0) return;
+	//ADD NEW DEVICE/ROSINERFACE BEGIN
+
+
+	//ADD NEW DEVICE/ROSINERFACE END
+	for (size_t i = 0; i< factories.size();++i)
+		for (size_t j = 0; j< i;++j)
+			if (factories[i]->type == factories[j]->type)
+				ROS_ERROR("SimulatedDevices factories types must be unique, but the same type '%s' is specified at indexes %d and %d in initFacotries() in SimulatedDevices.cpp", factories[i]->type.c_str(), (int)j, (int)i);
+}
+
+SimulatedDevices::SimulatedDevices(){}
+
+boost::shared_ptr<ROSInterface> SimulatedDevices::getInterface(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile){
+	initFactories();
+	for (size_t i = 0; i< factories.size();++i)
+		if (rosInterface.type==ROSInterfaceInfo::SimulatedDevice &&  factories[i]->type==rosInterface.subtype){
+			return factories[i]->getInterface(rosInterface, iauvFile);
+		}
+	return boost::shared_ptr<ROSInterface>();//empty pointer by default
+}
+
+void SimulatedDevices::applyConfig(SimulatedIAUV * auv, Vehicle &vehicleChars)
+{
+	for (size_t i = 0; i< factories.size();++i){
+		factories[i]->applyConfig(auv, vehicleChars);
+	}
+}
+
+SimulatedDeviceConfig::Ptr SimulatedDevices::processConfig(const xmlpp::Node* node, ConfigFile * config){
+	initFactories();
+	SimulatedDeviceConfig::Ptr dev;
+	std::string name;
+	xmlpp::Node::NodeList list = node->get_children();
+	for(xmlpp::Node::NodeList::iterator iter = list.begin(); iter != list.end(); ++iter){
+		xmlpp::Node* child=dynamic_cast<const xmlpp::Node*>(*iter);
+
+		if (child->get_name()=="name")
+			config->extractStringChar(child, name);
+		else if (child->get_name()!="text")
+			for (size_t i = 0; i< factories.size();++i)
+				if (factories[i]->type==child->get_name()){
+					dev = factories[i]->processConfig(child, config);
+					if (dev){
+						//common device XML properties, like name
+						dev->name = name;
+					}
+					return dev;//one device per SimulatedDevice tag, preceded by common properties
+				}
+	}
+	return dev;
+}
+
+SimulatedDeviceConfig::SimulatedDeviceConfig(std::string type){
+	this->type = type; //device/rosinterface type identifier for both "XML config" and a "factory"
+}
+
+SimulatedDevice::SimulatedDevice(SimulatedDeviceConfig * cfg){
+	this->type = cfg->type;
+	this->name = cfg->name;
+}

--- a/UWSim/src/SimulatedDevices.cpp
+++ b/UWSim/src/SimulatedDevices.cpp
@@ -11,6 +11,7 @@
 
 #include "SimulatedDevices.h"
 #include "ConfigXMLParser.h"
+#include "SimulatedDevice_Echo.h"
 #include "ros/ros.h"
 
 //a list of "factories" to initialize and apply a device or rosinterface
@@ -22,6 +23,7 @@ static void initFactories(){
 	if (factories.size()>0) return;
 	//ADD NEW DEVICE/ROSINERFACE BEGIN
 
+	factories.push_back(SimulatedDeviceConfig::Ptr(new SimulatedDeviceConfig_Echo()));
 
 	//ADD NEW DEVICE/ROSINERFACE END
 	for (size_t i = 0; i< factories.size();++i)

--- a/UWSim/src/SimulatedDevices.h
+++ b/UWSim/src/SimulatedDevices.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2013 Tallinn University of Technology.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Contributors:
+ *     Yuri Gavshin
+ */
+
+#ifndef SIMULATEDDEVICES_H_
+#define SIMULATEDDEVICES_H_
+
+#include <libxml++/libxml++.h>
+#include <iostream>
+#include <cstdlib>
+#include <list>
+#include <boost/smart_ptr/shared_ptr.hpp>
+
+struct ROSInterfaceInfo;
+struct SimulatedIAUV;
+struct ROSInterface;
+struct ConfigFile;
+struct Vehicle;
+
+//Base class for device/rosinterface "factory" and device's XML configuration
+class SimulatedDeviceConfig{
+public:
+	typedef boost::shared_ptr<SimulatedDeviceConfig> Ptr;
+
+	std::string type;	//device/rosinterface type identifier for both "XML config" and a "factory"
+	SimulatedDeviceConfig(std::string type);
+
+//common XML properties:
+	std::string name;
+
+//factory methods
+
+	//DRIVER: parses XML and returns "XML config", executed first
+	virtual SimulatedDeviceConfig::Ptr processConfig(const xmlpp::Node* node, ConfigFile * config) = 0;
+	//DRIVER: checks parsed XML configurations and sets SimulatedAUV's data, executed second
+	virtual void applyConfig( SimulatedIAUV * auv, Vehicle &vehicleChars) = 0;
+	//ROSINTERFACE: returns configured ROSInterface, executed third
+	virtual boost::shared_ptr<ROSInterface> getInterface(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile) = 0;
+
+	virtual ~SimulatedDeviceConfig(){};
+};
+
+//Base class for a simulated device
+class SimulatedDevice{
+public:
+	typedef boost::shared_ptr<SimulatedDevice> Ptr;
+
+	std::string type;//driver/rosinterface type
+	std::string name;//common property
+
+	SimulatedDevice(SimulatedDeviceConfig * cfg);
+};
+
+//Class added to SimulatedIAUV as devices->, put your data into into this class members or use all vector to store your device
+class SimulatedDevices{
+public:
+//Object members
+	std::vector<SimulatedDevice::Ptr> all;
+
+	SimulatedDevices();
+
+	//Applies parsed XML configurations by calling appropriate methods
+	//on all registered factories (set in initFactories() in SimulatedDevices.cpp)
+	void applyConfig(SimulatedIAUV * auv, Vehicle &vehicleChars);
+
+//Factory methods
+
+	//returns configured ROSInterface based on given XML configuration
+	static boost::shared_ptr<ROSInterface> getInterface(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile);
+
+	//Parses driver's XML configuration
+	static SimulatedDeviceConfig::Ptr processConfig(const xmlpp::Node* node, ConfigFile * config);
+};
+
+#endif /* SIMULATEDDEVICES_H_ */

--- a/UWSim/src/SimulatedIAUV.cpp
+++ b/UWSim/src/SimulatedIAUV.cpp
@@ -224,6 +224,9 @@ SimulatedIAUV::SimulatedIAUV(SceneBuilder *oscene, Vehicle vehicleChars) : urdf(
 		OSG_INFO << "Done adding an object picker..." << std::endl;
 	}
 
+	devices.reset(new SimulatedDevices());
+	devices->applyConfig(this, vehicleChars);
+
 	//Set-up a lamp attached to the vehicle: TODO
 	/*
   osg::Light *_light=new osg::Light;
@@ -270,4 +273,3 @@ void SimulatedIAUV::setVehiclePosition(double x, double y, double z, double roll
 void SimulatedIAUV::setVehiclePosition(osg::Matrixd m){
 	baseTransform->setMatrix(m);
 }
-

--- a/UWSim/src/SimulatedIAUV.h
+++ b/UWSim/src/SimulatedIAUV.h
@@ -40,6 +40,7 @@ public:
 	std::vector<GPSSensor> gps_sensors;
 	std::vector<DVLSensor> dvl_sensors;
 	std::vector<MultibeamSensor> multibeam_sensors;
+	boost::shared_ptr<SimulatedDevices> devices;
 
 	typedef enum {ARM5,PA10} arm_t;
 


### PR DESCRIPTION
These changes will simplify addition of new drivers/sensors and ROS interfaces into UWSim code with as little unneeded changes as possible (currently, only the SimulatedDevices.cpp (out of source files) file must be updated if new driver/interface is added).
It is also easy to convert existing interfaces into this new system, if needed...

Pull request consists of two commits - the first one changes the base code and the second one is an example driver (updated cirs.xml), which outputs a String (configured in driver's XML) on ROS interface. 
