### PR TITLE
Fixed URDF materials parsing and application (of transparent materials). Added possibility to set up ViewBuilder inside plugin and to visually debug physics.

### DIFF
--- a/uwsim/include/uwsim/BulletHfFluid/btHfFluidRigidDynamicsWorld.h
+++ b/uwsim/include/uwsim/BulletHfFluid/btHfFluidRigidDynamicsWorld.h
@@ -57,7 +57,7 @@ protected:
 	void drawHfFluidBuoyantConvexShape (btIDebugDraw* debugDrawer, btCollisionObject* object, btHfFluidBuoyantConvexShape* buoyantShape, int voxelDraw);
 	void drawHfFluidNormal (btIDebugDraw* debugDraw, btHfFluid* fluid);
 public:
-	
+	void	debugDraw(){debugDrawWorld();}
 	btHfFluidRigidDynamicsWorld(btDispatcher* dispatcher,btBroadphaseInterface* pairCache,btConstraintSolver* constraintSolver,btCollisionConfiguration* collisionConfiguration);
 
 	virtual ~btHfFluidRigidDynamicsWorld();

--- a/uwsim/include/uwsim/ConfigXMLParser.h
+++ b/uwsim/include/uwsim/ConfigXMLParser.h
@@ -252,9 +252,9 @@ public://made process and extract methods public to be used in Simulated Devices
 
   void processGeometry(urdf::Geometry * geometry, Geometry * geom);
   void processPose(urdf::Pose pose,double position[3], double rpy[3],double quat[4]);
-  int processVisual(boost::shared_ptr<const urdf::Visual> visual, Link &link, int nmat, std::vector<Material> &materials); //returns current material
+  int processVisual(boost::shared_ptr<const urdf::Visual> visual, Link &link, int &nmat, std::vector<Material> &materials); //returns current material
   void processJoint(boost::shared_ptr<const urdf::Joint> joint, Joint &jointVehicle,int parentLink,int childLink);
-  int processLink(boost::shared_ptr<const urdf::Link> link, Vehicle &vehicle, int nlink, int njoint, int nmat, std::vector<Material> &materials); //returns current link number
+  int processLink(boost::shared_ptr<const urdf::Link> link, Vehicle &vehicle, int nlink, int njoint, int &nmat, std::vector<Material> &materials); //returns current link number
   int processURDFFile(string file, Vehicle &vehicle);
 
   void postprocessVehicle(Vehicle &vehicle);

--- a/uwsim/include/uwsim/SimulatedDevice.h
+++ b/uwsim/include/uwsim/SimulatedDevice.h
@@ -25,6 +25,7 @@ struct ConfigFile;
 struct Vehicle;
 struct SceneBuilder;
 struct BulletPhysics;
+struct ViewBuilder;
 
 namespace uwsim {
   struct SimulatedDevice;
@@ -72,7 +73,9 @@ namespace uwsim {
     std::string getType(){return type;}
     typedef boost::shared_ptr<SimulatedDevice> Ptr;
     SimulatedDevice(SimulatedDeviceConfig * cfg);
-    virtual void applyPhysics( BulletPhysics * bulletPhysics) = 0;
+    virtual void applyPhysics( BulletPhysics * bulletPhysics){}
+    virtual void setViewBuilder( ViewBuilder * viewBuilder){}
+    
     virtual ~SimulatedDevice(){}
   };
 };

--- a/uwsim/src/ConfigXMLParser.cpp
+++ b/uwsim/src/ConfigXMLParser.cpp
@@ -496,7 +496,7 @@ void ConfigFile::processGeometry(urdf::Geometry * geometry, Geometry * geom){
 	geom->radius=sphere->radius;
      }
   }
-  int ConfigFile::processVisual(boost::shared_ptr<const urdf::Visual> visual,Link &link, int nmat, std::vector<Material> &materials){
+  int ConfigFile::processVisual(boost::shared_ptr<const urdf::Visual> visual,Link &link, int &nmat, std::vector<Material> &materials){
      processGeometry(visual->geometry.get(),link.geom.get());
      processPose(visual->origin,link.position,link.rpy,link.quat);
 
@@ -568,7 +568,7 @@ void ConfigFile::processGeometry(urdf::Geometry * geometry, Geometry * geom){
     }
   }
 
-  int ConfigFile::processLink(boost::shared_ptr<const urdf::Link> link,Vehicle &vehicle,int nlink,int njoint,int nmat, std::vector<Material> &materials){
+  int ConfigFile::processLink(boost::shared_ptr<const urdf::Link> link,Vehicle &vehicle,int nlink,int njoint,int &nmat, std::vector<Material> &materials){
     vehicle.links[nlink].name=link->name;
     vehicle.links[nlink].geom.reset( new Geometry);
     if(link->visual)
@@ -615,7 +615,8 @@ int ConfigFile::processURDFFile(string file, Vehicle &vehicle){
 	vehicle.nmaterials = model.materials_.size();
 	vehicle.materials.resize(vehicle.nmaterials);
 	boost::shared_ptr<const urdf::Link> root = model.getRoot();
-	processLink(root,vehicle,0,0,0,vehicle.materials);
+	int nmat = 0;
+	processLink(root,vehicle,0,0,nmat,vehicle.materials);
 	return 0;
 }
 

--- a/uwsim/src/URDFRobot.cpp
+++ b/uwsim/src/URDFRobot.cpp
@@ -92,6 +92,10 @@ URDFRobot::URDFRobot(osgOcean::OceanScene *oscene,Vehicle vehicle): KinematicCha
 	  osg::ref_ptr<osg::Material> material = new osg::Material();
           material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4(vehicle.materials[vehicle.links[i].material].r, vehicle.materials[vehicle.links[i].material].g, vehicle.materials[vehicle.links[i].material].b, vehicle.materials[vehicle.links[i].material].a));
 	  stateset->setAttribute(material);
+	  if (vehicle.materials[vehicle.links[i].material].a<1){
+	    stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+	    stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
+	  }
 	  link[i]->setStateSet(stateset);
 	}
    }

--- a/uwsim/src/ViewBuilder.cpp
+++ b/uwsim/src/ViewBuilder.cpp
@@ -179,6 +179,9 @@ bool ViewBuilder::init(ConfigFile &config, SceneBuilder *scene_builder) {
 
 	viewer->setSceneData(appgroup);
 
+	for (unsigned int j=0; j<scene_builder->iauvFile.size(); j++)
+		for (unsigned int i=0; i<scene_builder->iauvFile[j]->devices->all.size(); i++)
+			scene_builder->iauvFile[j]->devices->all.at(i)->setViewBuilder(this);
 	return true;
 }
 void ViewBuilder::init(){

--- a/uwsim/src/main.cpp
+++ b/uwsim/src/main.cpp
@@ -20,7 +20,7 @@
 #include <uwsim/SceneBuilder.h>
 #include <uwsim/ViewBuilder.h>
 #include <uwsim/PhysicsBuilder.h>
-
+#include "osgbCollision/GLDebugDrawer.h"
 #include <uwsim/UWSimUtils.h>
 
 using namespace std;
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
 	arguments->getApplicationUsage()->addCommandLineOption("--v","Be verbose. (OSG notify level NOTICE)");
 	arguments->getApplicationUsage()->addCommandLineOption("--vv","Be much verbose. (OSG notify level DEBUG)");
 	arguments->getApplicationUsage()->addCommandLineOption("--dataPath <path>","Search for models in this path, besides the default ones");
+        arguments->getApplicationUsage()->addCommandLineOption("--debugPhysics [<flag>]","Enable physics visualisation. 1 for wireframe, 2 for physics only. For other flag options refer to btIDebugDraw.h");
 
 	unsigned int helpType = 0;
 	if ((helpType = arguments->readHelpType()))
@@ -103,6 +104,17 @@ int main(int argc, char *argv[])
         if(config.enablePhysics)
 	  physicsBuilder.loadPhysics(&builder,config);
 
+	int drawPhysics = 0;
+	if (!arguments->read("--debugPhysics", osg::ArgumentParser::Parameter(drawPhysics)) && arguments->read("--debugPhysics"))
+		drawPhysics = 2;
+	boost::shared_ptr<osgbCollision::GLDebugDrawer> debugDrawer;
+	if (config.enablePhysics && drawPhysics>0){
+		debugDrawer.reset(new osgbCollision::GLDebugDrawer());
+		debugDrawer->setDebugMode(drawPhysics);
+		physicsBuilder.physics->dynamicsWorld->setDebugDrawer(debugDrawer.get());
+		builder.getRoot()->addChild(debugDrawer->getSceneGraph());
+	}
+
 	ViewBuilder view(config, &builder, arguments);
 	
 	view.init();
@@ -126,6 +138,11 @@ int main(int argc, char *argv[])
                     elapsed = 1./60.;
                   physicsBuilder.physics->stepSimulation(elapsed, 4, elapsed/4. );
                   prevSimTime = currSimTime;
+                  if (debugDrawer) {
+                    debugDrawer->BeginDraw();
+                    physicsBuilder.physics->dynamicsWorld->debugDraw();
+                    debugDrawer->EndDraw();
+                  }
 		}                
 
 		view.getViewer()->frame();


### PR DESCRIPTION
Fixed robot's materials parsing (when using urdf geometry, nmat wasn't updated as it should, fixed) and setting up (enabling transparency, previously alpha value was discarded, all materials were opaque).
Changed SimulatedDevice signature a bit to enable additional setup in ViewBuilder (new setViewBuilder method and made applyPhysics method optional to implement).
Enable physics debugging using --debugPhysics flag with optional numeric parameter.
