### PR TITLE
Changed physics simulation step logic and made simulatedDevices/SimulatedDeviceROS parent tags optional

### DIFF
--- a/uwsim/data/scenes/UWSimScene.dtd
+++ b/uwsim/data/scenes/UWSimScene.dtd
@@ -3,7 +3,7 @@
 <!-- elementos oceanScene -->
 <!ELEMENT oceanState (windx?,windy?,windSpeed?,depth?,reflectionDamping?,waveScale?,isNotChoppy?,choppyFactor?,crestFoamHeight?,oceanSurfaceHeight?,fog?,color?,attenuation?)>
 <!ELEMENT simParams (disableShaders?,resw?,resh?,offsetp?,offsetr?,enablePhysics?,gravity?,physicsWater?)>
-<!ELEMENT vehicle (name,file,jointValues?,position?,orientation?,virtualCamera*, structuredLightProjector*, rangeSensor*, objectPicker*, imu*, pressureSensor*, gpsSensor*, dvlSensor*, virtualRangeImage*,multibeamSensor*, simulatedDevices?)>
+<!ELEMENT vehicle (name,file,jointValues?,position?,orientation?,virtualCamera*, structuredLightProjector*, rangeSensor*, objectPicker*, imu*, pressureSensor*, gpsSensor*, dvlSensor*, virtualRangeImage*,multibeamSensor*, simulatedDevices?, echo*)>
 <!ELEMENT virtualCamera (name,relativeTo,resw?,resh?,position?,orientation?,baseline?,frameId?, parameters?, showpath?,grayscale?)>
 <!ELEMENT virtualRangeImage (name,relativeTo,resw?,resh?,position?,orientation?,parameters?)>
 <!ELEMENT structuredLightProjector (name,relativeTo,fov,image_name,visible?,position?,orientation?)>
@@ -16,7 +16,7 @@
 <!ELEMENT multibeamSensor (name,relativeTo,position?,orientation?, initAngle,finalAngle, angleIncr,range)>
 <!ELEMENT camera (freeMotion?,objectToTrack?,fov?,aspectRatio?,near?,far?,position?,lookAt?) >
 <!ELEMENT object (name,file,position,orientation,offsetp?,offsetr?,physics?)>
-<!ELEMENT rosInterfaces ((ROSOdomToPAT*)?, (PATToROSOdom*)?, (ArmToROSJointState*)?, (ROSJointStateToArm*)?, (VirtualCameraToROSImage*)?, (ROSImageToHUD*)?,(ROSTwistToPAT*)?, (RangeSensorToROSRange*)?, (ROSPoseToPAT*)?, (ImuToROSImu*)?, (PressureSensorToROS*)?, (GPSSensorToROS*)?, (DVLSensorToROS*)?, (RangeImageSensorToROSImage*)?,(multibeamSensorToLaserScan*)?, (SimulatedDeviceROS*)?,(contactSensorToROS*)?)>
+<!ELEMENT rosInterfaces ((ROSOdomToPAT*)?, (PATToROSOdom*)?, (ArmToROSJointState*)?, (ROSJointStateToArm*)?, (VirtualCameraToROSImage*)?, (ROSImageToHUD*)?,(ROSTwistToPAT*)?, (RangeSensorToROSRange*)?, (ROSPoseToPAT*)?, (ImuToROSImu*)?, (PressureSensorToROS*)?, (GPSSensorToROS*)?, (DVLSensorToROS*)?, (RangeImageSensorToROSImage*)?,(multibeamSensorToLaserScan*)?, (SimulatedDeviceROS*)?,(contactSensorToROS*)?,(echoROS*)?)>
 
 <!-- elementos comunes -->
 <!ELEMENT position (x,y,z)>

--- a/uwsim/data/scenes/cirs.xml
+++ b/uwsim/data/scenes/cirs.xml
@@ -254,11 +254,11 @@
         <name>g500_echo1</name>
         <info>Echo example 1</info>
       </echo>
-      <echo>
-        <name>g500_echo2</name>
-        <info>Echo example 2</info>
-      </echo>
     </simulatedDevices>
+    <echo>
+      <name>g500_echo2</name>
+      <info>Echo example 2</info>
+    </echo>
   </vehicle>
 
   <object>
@@ -383,18 +383,16 @@
         <rate>1</rate>
       </echoROS>
     </SimulatedDeviceROS>
-    <SimulatedDeviceROS>
-      <echoROS>
-        <name>g500_echo2</name>
-        <topic>g500/echo2</topic>
-        <rate>1</rate>
-      </echoROS>
-    </SimulatedDeviceROS>
     <contactSensorToROS>
       <name>girona500</name>
       <topic>g500/contactSensor</topic>
       <rate> 100 </rate>
     </contactSensorToROS>
+    <echoROS>
+      <name>g500_echo2</name>
+      <topic>g500/echo2</topic>
+      <rate>1</rate>
+    </echoROS>
   </rosInterfaces>
 </UWSimScene>
 

--- a/uwsim/include/uwsim/ConfigXMLParser.h
+++ b/uwsim/include/uwsim/ConfigXMLParser.h
@@ -269,6 +269,8 @@ public:
   list <ROSInterfaceInfo> ROSInterfaces;
   list <ROSInterfaceInfo> ROSPhysInterfaces; //Physics interfaces are loaded after physics
   PhysicsWater physicsWater;
+  double physicsFrequency;
+  int physicsSubSteps;
 
   ConfigFile(const std::string &fName);
 };

--- a/uwsim/include/uwsim/SimulatedDevices.h
+++ b/uwsim/include/uwsim/SimulatedDevices.h
@@ -31,6 +31,6 @@ public:
   static std::vector<boost::shared_ptr<ROSInterface> > getInterfaces(ROSInterfaceInfo & rosInterface, std::vector<boost::shared_ptr<SimulatedIAUV> > & iauvFile);
   
   //Parses driver's XML configuration
-  static std::vector<uwsim::SimulatedDeviceConfig::Ptr > processConfig(const xmlpp::Node* node, ConfigFile * config);
+  static std::vector<uwsim::SimulatedDeviceConfig::Ptr > processConfig(const xmlpp::Node* node, ConfigFile * config, bool isDevice = false);
 };
 #endif /* SIMULATEDDEVICES_H_ */

--- a/uwsim/src/main.cpp
+++ b/uwsim/src/main.cpp
@@ -136,7 +136,9 @@ int main(int argc, char *argv[])
                   double elapsed( currSimTime - prevSimTime );
                   if( view.getViewer()->getFrameStamp()->getFrameNumber() < 3 ) 
                     elapsed = 1./60.;
-                  physicsBuilder.physics->stepSimulation(elapsed, 4, elapsed/4. );
+                  int subSteps = fmax(0,config.physicsSubSteps);
+                  if (subSteps==0) subSteps = ceil(elapsed*config.physicsFrequency);//auto substep
+                  physicsBuilder.physics->stepSimulation(elapsed, subSteps, 1/config.physicsFrequency);
                   prevSimTime = currSimTime;
                   if (debugDrawer) {
                     debugDrawer->BeginDraw();


### PR DESCRIPTION
Physics:
- Changed stepSimulation call to be framerate-independent. Two parameters are parsed in the config file to tweak it:
  - physicsFrequency: simulation rate (default is 60, as in Bullet)
  - physicsSubSteps: in case the framerate is lower than 60, a max number of physics calculation steps to be done
    0 (default) for automatic number of substeps, i.e. ceil (elapsed/(1/physicsFrequency))
    For example if physicsSubSteps is set to 10 and physicsFrequency is 60, physics will be correct if FPS is higher than 6 (60/10).

Simuated devices:
- Changed cirs.xml and UWSimScene.dtd to showcase both types of simulated device configuration options.
