### PR TITLE
ROS type resource lookup for scene xml urdf and urdf geometries

### DIFF
--- a/uwsim/src/ConfigXMLParser.cpp
+++ b/uwsim/src/ConfigXMLParser.cpp
@@ -13,6 +13,7 @@
 #include <uwsim/ConfigXMLParser.h>
 #include <uwsim/SimulatorConfig.h>
 #include <osgDB/FileUtils>
+#include <ros/package.h>
 
 void ConfigFile::esPi(string in, double &param)
 {
@@ -699,7 +700,22 @@ int ConfigFile::processURDFFile(string file, Vehicle &vehicle)
 {
   urdf::Model model;
 
-  std::string file_fullpath = osgDB::findDataFile(file);
+  std::string file_fullpath;
+
+  if(file.substr(0,10) == std::string("package://"))
+  {
+    // the package name is between "package://" and the next '/' character, dig it out.
+    // where 10 is the length of "package://"
+    std::string package_path = ros::package::getPath(file.substr(10, file.find('/',10)-10));
+    // take string after package name
+    std::string rest_of_path = file.substr(file.find('/',10)); 
+    file_fullpath = package_path + rest_of_path;
+  }
+  else
+  {
+    file_fullpath = osgDB::findDataFile(file);
+  }
+
   if (file_fullpath == std::string("") || !model.initFile(file_fullpath))
   {
     osg::notify(osg::ALWAYS) << "Failed to parse urdf file " << file << std::endl;


### PR DESCRIPTION
Hola,

I've added a bit of code (actually pretty much the same) to 2 files to add support for the following use cases
- Non-fully resolved named in scene xml, vehice file tag:  
  <file>package://my_robot_description/robots/my_awesome_robot.urdf</file>
- Non-fully resolved names in mesh filenames in URDF  
  <mesh filename="package://my_robot_description/meshes/my_awesome_robot_part.stl"/>
