### PR TITLE
[CI] Update config for ROS Kinetic and Lunar.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,33 @@
 # Generic UWSim Travis Continuous Integration Configuration File
-sudo: required
-dist: trusty
-language:
-  - generic
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
 notifications:
   email:
     recipients:
       - perezsolerj@gmail.com
-    on_success: change #[always|never|change] # default: change
-    on_failure: change #[always|never|change] # default: always
-before_install:
-  - export ROS_DISTRO=indigo
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
-  - sudo rosdep init
-  - rosdep update
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"  PRERELEASE=true
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar"  PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
+    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="lunar"  PRERELEASE=true
 install:
-  # Create workspace
-  - mkdir -p ~/ros/ws_uwsim/src
-  - cd ~/ros/ws_uwsim/src
-  - wstool init .
-  - git clone -b $ROS_DISTRO-devel https://github.com/uji-ros-pkg/underwater_simulation.git
-  - rm -rf $REPOSITORY_NAME
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-  - cd ../
-  # Install dependencies for source repos
-  - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
-before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash  
-script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
Taking out a commit for CI update from #58.

Update CI config using [industrial_ci](https://github.com/ros-industrial/industrial_ci), a set of CI scripts that can also covers [ROS prerelease test](http://wiki.ros.org/regression_tests#Running_prerelease_test).

ROS Lunar is also added but as of today dependency isn't met so all jobs fail.