### PR TITLE
Fix build with CATKIN_ENABLE_TESTING=OFF

### DIFF
--- a/uwsim/CMakeLists.txt
+++ b/uwsim/CMakeLists.txt
@@ -26,7 +26,9 @@ find_package(catkin REQUIRED COMPONENTS
   roslaunch
 )
 
-roslaunch_add_file_check(data/scenes/launch)
+if(CATKIN_ENABLE_TESTING)
+  roslaunch_add_file_check(data/scenes/launch)
+endif(CATKIN_ENABLE_TESTING)
 
 # add package modules path, not needed in dependend packages
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")


### PR DESCRIPTION
The build currently fails with `-DCATKIN_ENABLE_TESTING=OFF` because `roslaunch_add_file_check` requires tests to be enabled. This patch conditionally disables the call when tests are disabled.