### PR TITLE
Interface examples can accept additional arguments (i.e. ROS node arg…

### DIFF
--- a/uwsim/interface_examples/gotoAbsolutePose.cpp
+++ b/uwsim/interface_examples/gotoAbsolutePose.cpp
@@ -44,7 +44,7 @@ void vehiclePoseCallback(const nav_msgs::Odometry& odom) {
 int main(int argc, char **argv) {
 
 
-	if (argc!=9) {
+	if (argc < 9) {
 		std::cerr << "USAGE: " << argv[0] << " <vehiclePoseTopic> <vehicleControlTopic> <x> <y> <z> <roll> <pitch> <yaw>" << std::endl;
 		std::cerr << "units are meters and radians." << std::endl;
 		return 0;

--- a/uwsim/interface_examples/gotoRelativePose.cpp
+++ b/uwsim/interface_examples/gotoRelativePose.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
 	ros::init(argc, argv, "gotoRelativePose");
 	ros::NodeHandle nh;
 
-	if (argc!=9) {
+	if (argc < 9) {
 		std::cerr << "USAGE: " << argv[0] << " <vehiclePoseTopic> <vehicleControlTopic> <rx> <ry> <rz> <rroll> <rpitch> <ryaw>" << std::endl;
 		std::cerr << "units are meters and radians." << std::endl;
 		return 0;

--- a/uwsim/interface_examples/makeVehicleSurvey.cpp
+++ b/uwsim/interface_examples/makeVehicleSurvey.cpp
@@ -23,7 +23,7 @@
 int main(int argc, char **argv) {
 
 
-	if (argc!=8) {
+	if (argc < 8) {
 		std::cerr << "USAGE: " << argv[0] << " <topic> <x> <y> <z> <yaw> <long> <step>" << std::endl;
 		std::cerr << "units in meters and radians" << std::endl;
 		return 0;

--- a/uwsim/interface_examples/setJointPosition.cpp
+++ b/uwsim/interface_examples/setJointPosition.cpp
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-	if (argc != 7) {
+	if (argc < 7) {
                 std::cerr << "Usage: " << argv[0] << "<topic> <q1> <q2> <q3> <q4> <q5>" << std::endl;
 		std::cerr << "Units are radians" << std::endl;
                 exit(0);

--- a/uwsim/interface_examples/setJointVelocity.cpp
+++ b/uwsim/interface_examples/setJointVelocity.cpp
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-	if (argc != 7) {
+	if (argc < 7) {
                 std::cerr << "Usage: " << argv[0] << "<topic> <qdot1> <qdot2> <qdot3> <qdot4> <qdot5>" << std::endl;
 		std::cerr << "Units are radians/simulated_time. Time scale to be implemented." << std::endl;
                 exit(0);

--- a/uwsim/interface_examples/setVehicleDisturbances.cpp
+++ b/uwsim/interface_examples/setVehicleDisturbances.cpp
@@ -38,7 +38,7 @@ void vehiclePoseCallback(const nav_msgs::Odometry& odom) {
 
 int main(int argc, char **argv) {
 
-	if (argc!=9) {
+	if (argc < 9) {
 		std::cerr << "USAGE: " << argv[0] << " <vehiclePoseTopic> <controlTopic> <ax> <ay> <az> <aroll> <apitch> <ayaw>" << std::endl;
 		std::cerr << "<ax> <ay> <az> <ayaw> is the maximum desired variation on the vehicle pose" << std::endl;
  		std::cerr << "units in meters and radians" << std::endl;

--- a/uwsim/interface_examples/setVehiclePose.cpp
+++ b/uwsim/interface_examples/setVehiclePose.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 	ros::init(argc, argv, "setVehiclePose");
 	ros::NodeHandle nh;
 
-	if (argc!=8) {
+	if (argc < 8) {
 		std::cerr << "USAGE: " << argv[0] << " <topic> <x> <y> <z> <roll> <pitch> <yaw>" << std::endl;
 		std::cerr << "units are in meters and radians." << std::endl;
 		return 0;

--- a/uwsim/interface_examples/setVehiclePosition.cpp
+++ b/uwsim/interface_examples/setVehiclePosition.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 	ros::init(argc, argv, "setVehiclePosition");
 	ros::NodeHandle nh;
 
-	if (argc!=8) {
+	if (argc < 8) {
 		std::cerr << "USAGE: " << argv[0] << " <topic> <x> <y> <z> <roll> <pitch> <yaw>" << std::endl;
 		std::cerr << "units in meters and radians" << std::endl;
 		return 0;

--- a/uwsim/interface_examples/setVehicleTwist.cpp
+++ b/uwsim/interface_examples/setVehicleTwist.cpp
@@ -21,7 +21,7 @@
 int main(int argc, char **argv) {
 
 
-	if (argc!=8) {
+	if (argc < 8) {
 		std::cerr << "USAGE: " << argv[0] << " <topic> <vx> <vy> <vz> <vroll> <vpitch> <vyaw>" << std::endl;
 		std::cerr << "units are displacement/simulated_time. Time scale to be implemented." << std::endl;
 		return 0;

--- a/uwsim/interface_examples/setVehicleVelocity.cpp
+++ b/uwsim/interface_examples/setVehicleVelocity.cpp
@@ -21,7 +21,7 @@
 int main(int argc, char **argv) {
 
 
-	if (argc!=8) {
+	if (argc < 8) {
 		std::cerr << "USAGE: " << argv[0] << " <topic> <vx> <vy> <vz> <vroll> <vpitch> <vyaw>" << std::endl;
 		std::cerr << "units are displacement/simulated_time. Time scale to be implemented." << std::endl;
 		return 0;


### PR DESCRIPTION
Changed the limit of arguments allowed by the interface examples (gotoAbsolutePose, setVehiclePosition, setVehicleTwist, etc). This enables making multiple calls to the setVehicleVelocity interface using different node names, for example: 

`rosrun uwsim setVehicleVelocity /auv1/dataNavigator 1 0 0 0 0 0 __name:=vehicle1`
`rosrun uwsim setVehicleVelocity /auv1/dataNavigator 2 0 0 0 0 0 __name:=vehicle2`